### PR TITLE
Add Call Converter Util class

### DIFF
--- a/src/main/java/com/jakewharton/retrofit2/adapter/rxjava2/RxCallConverter.java
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/rxjava2/RxCallConverter.java
@@ -1,0 +1,24 @@
+package com.jakewharton.retrofit2.adapter.rxjava2;
+
+import io.reactivex.Observable;
+import retrofit2.Call;
+import retrofit2.Response;
+
+public final class RxCallConverter {
+
+    public static <R> Observable<Response<R>> toResponseObservable(Call<R> call) {
+        return toCallObservable(call);
+    }
+
+    public static <R> Observable<R> toBodyObservable(Call<R> call) {
+        return new BodyObservable<>(toCallObservable(call));
+    }
+
+    public static <R> Observable<Result<R>> toResultObservable(Call<R> call) {
+        return new ResultObservable<>(toCallObservable(call));
+    }
+    
+    private static <R> CallObservable<R> toCallObservable(Call<R> call) {
+        return new CallObservable<>(call);
+    }
+}

--- a/src/main/java/com/jakewharton/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/rxjava2/RxJava2CallAdapter.java
@@ -23,6 +23,8 @@ import retrofit2.Call;
 import retrofit2.CallAdapter;
 import retrofit2.Response;
 
+import static com.jakewharton.retrofit2.adapter.rxjava2.RxCallConverter.*;
+
 final class RxJava2CallAdapter implements CallAdapter<Object> {
   private final Type responseType;
   private final Scheduler scheduler;
@@ -50,15 +52,13 @@ final class RxJava2CallAdapter implements CallAdapter<Object> {
   }
 
   @Override public <R> Object adapt(Call<R> call) {
-    Observable<Response<R>> responseObservable = new CallObservable<>(call);
-
     Observable<?> observable;
     if (isResult) {
-      observable = new ResultObservable<>(responseObservable);
+      observable = toResultObservable(call);
     } else if (isBody) {
-      observable = new BodyObservable<>(responseObservable);
+      observable = toBodyObservable(call);
     } else {
-      observable = responseObservable;
+      observable = toResponseObservable(call);
     }
 
     if (scheduler != null) {


### PR DESCRIPTION
I am not sure if you think this will add value or is supposed to be in the main library, but i added a utility class that is supposed to help convert `Call<ConcreteClass>` into an `Observable<ConcreteClass>` or `Observable<Result<ConcreteClass>>` or `Observable<Response<ConcreteClass>>` and still pretty much work the same way as the adapter.

i have a reusable standalone module using retrofit2 connecting to our API, which is currently defines the endpoints inside retrofit2 services as `Call<ConcreteClass>` and its used across multiple different project, i am trying to start to migrate those from calls to Observables and i am looking for a good way to do it which this seems to be ok.